### PR TITLE
make the API pure UTF-8

### DIFF
--- a/src/ODBC.jl
+++ b/src/ODBC.jl
@@ -4,9 +4,9 @@ using DataFrames
 using DataArrays
 using Dates
 
-export advancedconnect, 
-       query, querymeta, @query, @sql_str, 
-       Connection, Metadata, conn, Connections, 
+export advancedconnect,
+       query, querymeta, @query, @sql_str,
+       Connection, Metadata, conn, Connections,
        disconnect, listdrivers, listdsns
 
 include("ODBC_Types.jl")
@@ -14,11 +14,11 @@ include("ODBC_API.jl")
 
 # Holds metadata related to an executed query resultset
 type Metadata
-    querystring::String
+    querystring::UTF8String
     cols::Int
     rows::Int
     colnames::Array{UTF8String}
-    coltypes::Array{(String, Int16)}
+    coltypes::Array{(UTF8String, Int16)}
     colsizes::Array{Int}
     coldigits::Array{Int16}
     colnulls::Array{Int16}
@@ -38,20 +38,20 @@ Base.show(io::IO,meta::Metadata) = begin
                               Sizes=meta.colsizes,
                               Digits=meta.coldigits,
                               Nullable=meta.colnulls))
-    end 
+    end
 end
 
-# Connection object holds information related to each 
+# Connection object holds information related to each
 # established connection and retrieved resultsets
 type Connection
-    dsn::String
+    dsn::UTF8String
     number::Int
     dbc_ptr::Ptr{Void}
     stmt_ptr::Ptr{Void}
-    
-    # Holding a reference to the last resultset is useful if the user 
-    # runs several test queries just using `query()` or `sql"..."` and 
-    # then realizes the last resultset should actually be saved to a variable. 
+
+    # Holding a reference to the last resultset is useful if the user
+    # runs several test queries just using `query()` or `sql"..."` and
+    # then realizes the last resultset should actually be saved to a variable.
     resultset::Any
 end
 
@@ -66,7 +66,7 @@ Base.show(io::IO,conn::Connection) = begin
         if conn.resultset == null_resultset
             print(io, "Contains resultset(s)? No")
         else
-            print(io, "Contains resultset(s)? Yes") 
+            print(io, "Contains resultset(s)? Yes")
         end
     end
 end
@@ -74,16 +74,16 @@ end
 Base.show(io::IO, conns::Vector{Connection}) = map(show, conns)
 
 # Global module consts and variables
-typealias Output Union(DataType,String)
+typealias Output Union(DataType,UTF8String)
 
 const null_resultset = DataFrame()
 const null_conn = Connection("", 0, C_NULL, C_NULL, null_resultset)
-const null_meta = Metadata("", 0, 0, UTF8String[], (String,Int16)[], Int[], Int16[], Int16[])
+const null_meta = Metadata("", 0, 0, UTF8String[], (UTF8String,Int16)[], Int[], Int16[], Int16[])
 
 global env = C_NULL
 
 # For managing references to multiple connections
-global Connections = Connection[] 
+global Connections = Connection[]
 
 #Create default connection = null
 global conn = null_conn

--- a/src/ODBC_API.jl
+++ b/src/ODBC_API.jl
@@ -20,12 +20,12 @@
  #Resultset Retrieval Functions
  #DBMS Meta Functions
  #Error Handling and Diagnostics
- 
+
 #### Macros and Utility Functions ####
 
-# MULTIROWFETCH sets the default rowset fetch size 
+# MULTIROWFETCH sets the default rowset fetch size
 # used in retrieving resultset blocks from queries
-const MULTIROWFETCH = 65535 
+const MULTIROWFETCH = 65535
 
 # success codes
 const SQL_SUCCESS           = int16(0)
@@ -62,24 +62,24 @@ macro FAILED(func)
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms712400(v=vs.85).aspx
-function SQLDrivers(env::Ptr{Void}, 
-                    driver_desc::Array{Uint8,1}, 
-                    desc_length::Array{Int16,1}, 
-                    driver_attr::Array{Uint8,1}, 
+function SQLDrivers(env::Ptr{Void},
+                    driver_desc::Array{Uint8,1},
+                    desc_length::Array{Int16,1},
+                    driver_attr::Array{Uint8,1},
                     attr_length::Array{Int16,1})
-    @windows_only begin 
+    @windows_only begin
         ret = ccall((:SQLDrivers, odbc_dm), stdcall, Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, 
+                    (Ptr{Void}, Int16, Ptr{Uint8},
                     Int16, Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
-                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc), 
-                    desc_length, driver_attr, length(driver_attr), attr_length) 
+                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc),
+                    desc_length, driver_attr, length(driver_attr), attr_length)
     end
     @unix_only begin
         ret = ccall((:SQLDrivers, odbc_dm), Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, 
+                    (Ptr{Void}, Int16, Ptr{Uint8},
                      Int16, Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
-                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc), 
-                    desc_length, driver_attr, length(driver_attr), attr_length) 
+                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc),
+                    desc_length, driver_attr, length(driver_attr), attr_length)
     end
     return ret
 end
@@ -91,18 +91,18 @@ function SQLDataSources(env::Ptr{Void},
                         dsn_attr::Array{Uint8,1},
                         attr_length::Array{Int16,1})
     @windows_only begin
-        ret = ccall((:SQLDataSources, odbc_dm), stdcall, Int16, 
-                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16, 
+        ret = ccall((:SQLDataSources, odbc_dm), stdcall, Int16,
+                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16,
                      Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
                     env, SQL_FETCH_NEXT, dsn_desc, length(dsn_desc),
-                    desc_length, dsn_attr, length(dsn_attr), attr_length) 
+                    desc_length, dsn_attr, length(dsn_attr), attr_length)
     end
     @unix_only begin
         ret = ccall((:SQLDataSources, odbc_dm), Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16, 
+                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16,
                      Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
                     env, SQL_FETCH_NEXT, dsn_desc, length(dsn_desc),
-                    desc_length, dsn_attr, length(dsn_attr), attr_length) 
+                    desc_length, dsn_attr, length(dsn_attr), attr_length)
     end
     return ret
 end
@@ -113,8 +113,8 @@ end
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms712455(v=vs.85).aspx
 # Description: allocates an environment, connection, statement, or descriptor handle
 # Valid handle types
-const SQL_HANDLE_ENV  = int16(1)  
-const SQL_HANDLE_DBC  = int16(2) 
+const SQL_HANDLE_ENV  = int16(1)
+const SQL_HANDLE_DBC  = int16(2)
 const SQL_HANDLE_STMT = int16(3)
 const SQL_HANDLE_DESC = int16(4)
 const SQL_NULL_HANDLE = C_NULL
@@ -122,14 +122,14 @@ const SQL_NULL_HANDLE = C_NULL
 #Status: Tested on Windows, Linux, Mac 32/64-bit
 function SQLAllocHandle(handletype::Int16, parenthandle::Ptr{Void}, handle::Array{Ptr{Void},1})
     @windows_only begin
-        ret = ccall((:SQLAllocHandle, odbc_dm), stdcall, Int16, 
+        ret = ccall((:SQLAllocHandle, odbc_dm), stdcall, Int16,
                     (Int16, Ptr{Void}, Ptr{Void}),
-                    handletype, parenthandle, handle) 
+                    handletype, parenthandle, handle)
     end
     @unix_only begin
         ret = ccall((:SQLAllocHandle, odbc_dm), Int16,
                     (Int16, Ptr{Void}, Ptr{Void}),
-                    handletype, parenthandle, handle) 
+                    handletype, parenthandle, handle)
     end
     return ret
 end
@@ -139,7 +139,7 @@ end
 # Description: frees resources associated with a specific environment, connection, statement, or descriptor handle
 # See SQLAllocHandle for valid handle types
 # Status: Tested on Windows, Linux, Mac 32/64-bit
-function SQLFreeHandle(handletype::Int16,handle::Ptr{Void}) 
+function SQLFreeHandle(handletype::Int16,handle::Ptr{Void})
     @windows_only begin
         ret = ccall((:SQLFreeHandle, odbc_dm), stdcall, Int16,
                     (Int16, Ptr{Void}), handletype, handle)
@@ -165,7 +165,7 @@ const SQL_CP_RELAXED_MATCH = uint(1)
 const SQL_CP_STRICT_MATCH = uint(0)
 const SQL_ATTR_ODBC_VERSION = 200
 const SQL_OV_ODBC2 = 2
-const SQL_OV_ODBC3 = 3 
+const SQL_OV_ODBC3 = 3
 const SQL_ATTR_OUTPUT_NTS = 10001
 const SQL_TRUE = 1
 const SQL_FALSE = 0
@@ -173,12 +173,12 @@ const SQL_FALSE = 0
 #Status: Tested on Windows, Linux, Mac 32/64-bit
 function SQLSetEnvAttr{T<:Union(Int,Uint)}(env_handle::Ptr{Void}, attribute::Int, value::T)
     @windows_only begin
-        ret = ccall((:SQLSetEnvAttr, odbc_dm), stdcall, Int16, 
-                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0) 
+        ret = ccall((:SQLSetEnvAttr, odbc_dm), stdcall, Int16,
+                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0)
     end
     @unix_only begin
-        ret = ccall((:SQLSetEnvAttr, odbc_dm), Int16, 
-                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0) 
+        ret = ccall((:SQLSetEnvAttr, odbc_dm), Int16,
+                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0)
     end
     return ret
 end
@@ -187,17 +187,17 @@ end
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms709276(v=vs.85).aspx
 # Description: returns the current setting of an environment attribute
 # Valid attributes: See SQLSetEnvAttr
-# Status: 
+# Status:
 function SQLGetEnvAttr(env::Ptr{Void},attribute::Int,value::Array{Int,1},bytes_returned::Array{Int,1})
     @windows_only begin
-        ret = ccall((:SQLGetEnvAttr, odbc_dm), stdcall, Int16, 
+        ret = ccall((:SQLGetEnvAttr, odbc_dm), stdcall, Int16,
                     (Ptr{Void}, Int, Ptr{Int}, Int, Ptr{Int}),
-                    env, attribute, value, 0, bytes_returned) 
+                    env, attribute, value, 0, bytes_returned)
     end
     @unix_only begin
-        ret = ccall((:SQLGetEnvAttr, odbc_dm), Int16, 
+        ret = ccall((:SQLGetEnvAttr, odbc_dm), Int16,
                     (Ptr{Void}, Int, Ptr{Int}, Int, Ptr{Int}),
-                    env, attribute, value, 0, bytes_returned) 
+                    env, attribute, value, 0, bytes_returned)
     end
     return ret
 end
@@ -209,14 +209,14 @@ end
 const SQL_ATTR_ACCESS_MODE = 101
 const SQL_MODE_READ_ONLY = uint(1)
 const SQL_MODE_READ_WRITE = uint(0)
-#const SQL_ATTR_ASYNC_DBC_EVENT 
+#const SQL_ATTR_ASYNC_DBC_EVENT
 #pointer
-#const SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE 
+#const SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
 #const SQL_ASYNC_DBC_ENABLE_ON = uint()
 #const SQL_ASYNC_DBC_ENABLE_OFF = uint()
-#const SQL_ATTR_ASYNC_DBC_PCALLBACK 
+#const SQL_ATTR_ASYNC_DBC_PCALLBACK
 #pointer
-#const SQL_ATTR_ASYNC_DBC_PCONTEXT 
+#const SQL_ATTR_ASYNC_DBC_PCONTEXT
 #pointer
 const SQL_ATTR_ASYNC_ENABLE = 4
 const SQL_ASYNC_ENABLE_OFF = uint(0)
@@ -228,10 +228,10 @@ const SQL_ATTR_CONNECTION_TIMEOUT = 113
 #uint of how long you want the connection timeout
 const SQL_ATTR_CURRENT_CATALOG = 109
 #string/Ptr{Uint8} of default database to use
-#const SQL_ATTR_DBC_INFO_TOKEN 
+#const SQL_ATTR_DBC_INFO_TOKEN
 #pointer
 const SQL_ATTR_ENLIST_IN_DTC = 1207
-#pointer: Pass a DTC OLE transaction object that specifies the transaction to export to 
+#pointer: Pass a DTC OLE transaction object that specifies the transaction to export to
 # SQL Server, or SQL_DTC_DONE to end the connection's DTC association.
 const SQL_ATTR_LOGIN_TIMEOUT = 103
 #uint of how long you want the login timeout
@@ -251,10 +251,10 @@ const SQL_OPT_TRACE_ON = uint(1)
 const SQL_ATTR_TRACEFILE = 105
 #A null-terminated character string containing the name of the trace file.
 const SQL_ATTR_TRANSLATE_LIB = 106
-# A null-terminated character string containing the name of a library containing the functions SQLDriverToDataSource and 
+# A null-terminated character string containing the name of a library containing the functions SQLDriverToDataSource and
 # SQLDataSourceToDriver that the driver accesses to perform tasks such as character set translation.
 const SQL_ATTR_TRANSLATE_OPTION = 107
-#A 32-bit flag value that is passed to the translation DLL. 
+#A 32-bit flag value that is passed to the translation DLL.
 const SQL_ATTR_TXN_ISOLATION = 108
 #A 32-bit bitmask that sets the transaction isolation level for the current connection.
 
@@ -266,13 +266,13 @@ const SQL_NTS = -3
 
 #length of string or binary stream
 #Status:
-function SQLSetConnectAttr(dbc::Ptr{Void},attribute::Int,value::Union(String,Uint),value_length::Int)
+function SQLSetConnectAttr(dbc::Ptr{Void},attribute::Int,value::Union(UTF8String,Uint),value_length::Int)
     @windows_only ret = ccall( (:SQLSetConnectAttr, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Int,typeof(value)==String?Ptr{Uint8}:Ptr{Uint},Int),
-        dbc,attribute,value,value_length) 
+        Int16, (Ptr{Void},Int,typeof(value)==UTF8String?Ptr{Uint8}:Ptr{Uint},Int),
+        dbc,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetConnectAttr, odbc_dm),
-            Int16, (Ptr{Void},Int,typeof(value)==String?Ptr{Uint8}:Ptr{Uint},Int),
-            dbc,attribute,value,value_length) 
+            Int16, (Ptr{Void},Int,typeof(value)==UTF8String?Ptr{Uint8}:Ptr{Uint},Int),
+            dbc,attribute,value,value_length)
     return ret
 end
 
@@ -289,10 +289,10 @@ const SQL_CD_FALSE = 0
 function SQLGetConnectAttr{T,N}(dbc::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetConnectAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+        dbc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetConnectAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+            dbc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -309,20 +309,20 @@ const SQL_ATTR_ROW_ARRAY_SIZE = 27
 function SQLSetStmtAttr(stmt::Ptr{Void},attribute::Int,value::Uint,value_length::Int)
     @windows_only ret = ccall( (:SQLSetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Uint,Int),
-        stmt,attribute,value,value_length) 
+        stmt,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Uint,Int),
-            stmt,attribute,value,value_length) 
+            stmt,attribute,value,value_length)
     return ret
 end
 
 function SQLSetStmtAttr(stmt::Ptr{Void},attribute::Int,value::Array{Int},value_length::Int)
     @windows_only ret = ccall( (:SQLSetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{Int},Int),
-        stmt,attribute,value,value_length) 
+        stmt,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{Int},Int),
-            stmt,attribute,value,value_length) 
+            stmt,attribute,value,value_length)
     return ret
 end
 
@@ -330,18 +330,18 @@ end
 function SQLGetStmtAttr{T,N}(stmt::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        stmt,attribute,value,sizeof(T)*N,bytes_returned) 
+        stmt,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            stmt,attribute,value,sizeof(T)*N,bytes_returned) 
+            stmt,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
 #SQLFreeStmt
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms709284(v=vs.85).aspx
-#Description: stops processing associated with a specific statement, 
-# closes any open cursors associated with the statement, 
-# discards pending results, or, optionally, 
+#Description: stops processing associated with a specific statement,
+# closes any open cursors associated with the statement,
+# discards pending results, or, optionally,
 # frees all resources associated with the statement handle.
 #Valid param
 const SQL_CLOSE = uint16(0)
@@ -350,12 +350,12 @@ const SQL_UNBIND = uint16(2)
 
 #Status:
 function SQLFreeStmt(stmt::Ptr{Void},param::Uint16)
-    @windows_only ret = ccall( (:SQLFreeStmt, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Uint16), 
-        stmt, param) 
+    @windows_only ret = ccall( (:SQLFreeStmt, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Uint16),
+        stmt, param)
     @unix_only ret = ccall( (:SQLFreeStmt, odbc_dm),
-            Int16, (Ptr{Void},Uint16), 
-            stmt, param) 
+            Int16, (Ptr{Void},Uint16),
+            stmt, param)
     return ret
 end
 
@@ -363,10 +363,10 @@ end
 function SQLSetDescField{T,N}(desc::Ptr{Void},i::Int16,field_id::Int16,value::Array{T,N},value_length::Array{Int,1})
     @windows_only ret = ccall( (:SQLSetDescField, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int),
-        desc,field_id,value,value_length) 
+        desc,field_id,value,value_length)
     @unix_only ret = ccall( (:SQLSetDescField, odbc_dm),
             Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int),
-            desc,field_id,value,value_length) 
+            desc,field_id,value,value_length)
     return ret
 end
 
@@ -374,10 +374,10 @@ end
 function SQLGetDescField{T,N}(desc::Ptr{Void},i::Int16,attribute::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetDescField, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int,Ptr{Int}),
-        desc,attribute,value,sizeof(T)*N,bytes_returned) 
+        desc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetDescField, odbc_dm),
             Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int,Ptr{Int}),
-            desc,attribute,value,sizeof(T)*N,bytes_returned) 
+            desc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -385,10 +385,10 @@ end
 function SQLGetDescRec(desc::Ptr{Void},i::Int16,name::Array{Uint8,1},name_length::Array{Int16,1},type_ptr::Array{Int16,1},subtype_ptr::Array{Int16,1},length_ptr::Array{Int,1},precision_ptr::Array{Int16,1},scale_ptr::Array{Int16,1},nullable_ptr::Array{Int16,1},)
     @windows_only ret = ccall( (:SQLGetDescRec, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16},Ptr{Int16}),
-        desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr) 
+        desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr)
     @unix_only ret = ccall( (:SQLGetDescRec, odbc_dm),
             Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16},Ptr{Int16}),
-            desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr) 
+            desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr)
     return ret
 end
 
@@ -396,25 +396,25 @@ end
 function SQLCopyDesc(source_desc::Ptr{Void},dest_desc::Ptr{Void})
     @windows_only ret = ccall( (:SQLCopyDesc, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void}),
-        source_desc,dest_desc) 
+        source_desc,dest_desc)
     @unix_only ret = ccall( (:SQLCopyDesc, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void}),
-            source_desc,dest_desc) 
+            source_desc,dest_desc)
     return ret
 end
 
-### Connection Functions ### 
+### Connection Functions ###
 # SQLConnect
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms711810(v=vs.85).aspx
 # Description: establishes connections to a driver and a data source
 # Status:
-function SQLConnect(dbc::Ptr{Void},dsn::String,username::String,password::String)
-    @windows_only ret = ccall( (:SQLConnect, odbc_dm), stdcall, 
+function SQLConnect(dbc::Ptr{Void},dsn::UTF8String,username::UTF8String,password::UTF8String)
+    @windows_only ret = ccall( (:SQLConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        dbc,dsn,length(dsn),username,length(username),password,length(password)) 
+        dbc,dsn,sizeof(dsn),username,sizeof(username),password,sizeof(password))
     @unix_only ret = ccall( (:SQLConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            dbc,dsn,length(dsn),username,length(username),password,length(password)) 
+            dbc,dsn,sizeof(dsn),username,sizeof(username),password,sizeof(password))
     return ret
 end
 
@@ -427,26 +427,26 @@ const SQL_DRIVER_COMPLETE_REQUIRED = uint16(3)
 const SQL_DRIVER_NOPROMPT = uint16(0)
 const SQL_DRIVER_PROMPT = uint16(2)
 #Status:
-function SQLDriverConnect(dbc::Ptr{Void},window_handle::Ptr{Void},conn_string::String,out_conn::Ptr{Void},out_buff::Array{Int16,1},driver_prompt::Uint16)
-    @windows_only ret = ccall( (:SQLDriverConnect, odbc_dm), stdcall, 
+function SQLDriverConnect(dbc::Ptr{Void},window_handle::Ptr{Void},conn_string::UTF8String,out_conn::Ptr{Void},out_buff::Array{Int16,1},driver_prompt::Uint16)
+    @windows_only ret = ccall( (:SQLDriverConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},Uint16),
-        dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
+        dbc,window_handle,conn_string,sizeof(conn_string),out_conn,0,out_buff,driver_prompt)
     @unix_only ret = ccall( (:SQLDriverConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},Uint16),
-            dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
+            dbc,window_handle,conn_string,sizeof(conn_string),out_conn,0,out_buff,driver_prompt)
     return ret
 end
 #SQLBrowseConnect
  #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714565(v=vs.85).aspx
  #Description: supports an iterative method of discovering and enumerating the attributes and attribute values required to connect to a data source
  #Status:
-function SQLBrowseConnect(dbc::Ptr{Void},instring::String,outstring::Array{Uint8,1},indicator::Array{Int16,1})
+function SQLBrowseConnect(dbc::Ptr{Void},instring::UTF8String,outstring::Array{Uint8,1},indicator::Array{Int16,1})
     @windows_only ret = ccall( (:SQLBrowseConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-        dbc,instring,length(instring),outstring,length(outstring),indicator) 
+        dbc,instring,sizeof(instring),outstring,sizeof(outstring),indicator)
     @unix_only ret = ccall( (:SQLBrowseConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-            dbc,instring,length(instring),outstring,length(outstring),indicator) 
+            dbc,instring,sizeof(instring),outstring,sizeof(outstring),indicator)
     return ret
 end
 #SQLDisconnect
@@ -455,27 +455,27 @@ end
  #Status:
 function SQLDisconnect(dbc::Ptr{Void})
     @windows_only ret = ccall( (:SQLDisconnect, odbc_dm), stdcall,
-        Int16, (Ptr{Void},), 
-        dbc) 
+        Int16, (Ptr{Void},),
+        dbc)
     @unix_only ret = ccall( (:SQLDisconnect, odbc_dm),
-            Int16, (Ptr{Void},), 
-            dbc) 
+            Int16, (Ptr{Void},),
+            dbc)
     return ret
 end
 #SQLGetFunctions
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms709291(v=vs.85).aspx
 #Descriptions:
 #Valid functionid
- 
+
 #supported will be SQL_TRUE or SQL_FALSE
 #Status:
 function SQLGetFunctions(dbc::Ptr{Void},functionid::Uint16,supported::Array{Uint16,1})
     @windows_only ret = ccall( (:SQLGetFunctions, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Ptr{Uint16}),
-        dbc,functionid,supported) 
+        dbc,functionid,supported)
     @unix_only ret = ccall( (:SQLGetFunctions, odbc_dm),
             Int16, (Ptr{Void},Uint16,Ptr{Uint16}),
-            dbc,functionid,supported) 
+            dbc,functionid,supported)
     return ret
 end
 
@@ -486,25 +486,25 @@ end
 function SQLGetInfo{T,N}(dbc::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetInfo, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+        dbc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetInfo, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+            dbc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
-#### Query Functions #### 
+#### Query Functions ####
 #SQLNativeSql
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714575(v=vs.85).aspx
 #Description: returns the SQL string as modified by the driver
 #Status:
-function SQLNativeSql(dbc::Ptr{Void},query_string::String,output_string::Array{Uint8,1},length_ind::Array{Int,1})
+function SQLNativeSql(dbc::Ptr{Void},query_string::UTF8String,output_string::Array{Uint8,1},length_ind::Array{Int,1})
     @windows_only ret = ccall( (:SQLNativeSql, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int,Ptr{Uint8},Int,Ptr{Int}),
-        dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind) 
+        dbc,query_string,sizeof(query_string),output_string,sizeof(output_string),length_ind)
     @unix_only ret = ccall( (:SQLNativeSql, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int,Ptr{Uint8},Int,Ptr{Int}),
-            dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind) 
+            dbc,query_string,sizeof(query_string),output_string,sizeof(output_string),length_ind)
     return ret
 end
 
@@ -512,15 +512,15 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714632(v=vs.85).aspx
 #Description:
 #valid sqltype
-#const SQL_ALL_TYPES = 
+#const SQL_ALL_TYPES =
 #Status:
 function SQLGetTypeInfo(stmt::Ptr{Void},sqltype::Int16)
     @windows_only ret = ccall( (:SQLGetTypeInfo, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16),
-        stmt,sqltype) 
+        stmt,sqltype)
     @unix_only ret = ccall( (:SQLGetTypeInfo, odbc_dm),
             Int16, (Ptr{Void},Int16),
-            stmt,sqltype) 
+            stmt,sqltype)
     return ret
 end
 
@@ -528,21 +528,21 @@ end
 function SQLPutData{T}(stmt::Ptr{Void},data::Array{T},data_length::Int)
     @windows_only ret = ccall( (:SQLPutData, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{T},Int),
-        stmt,data,data_length) 
+        stmt,data,data_length)
     @unix_only ret = ccall( (:SQLPutData, odbc_dm),
             Int16, (Ptr{Void},Ptr{T},Int),
-            stmt,data,data_length) 
+            stmt,data,data_length)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710926(v=vs.85).aspx
-function SQLPrepare(stmt::Ptr{Void},query_string::String)
+function SQLPrepare(stmt::Ptr{Void},query_string::UTF8String)
     @windows_only ret = ccall( (:SQLPrepare, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16),
-        stmt,query_string,sizeof(query_string)) 
+        stmt,query_string,sizeof(query_string))
     @unix_only ret = ccall( (:SQLPrepare, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16),
-            stmt,query_string,sizeof(query_string)) 
+            stmt,query_string,sizeof(query_string))
     return ret
 end
 
@@ -550,10 +550,10 @@ end
 function SQLExecute(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLExecute, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLExecute, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -561,10 +561,10 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms713611(v=vs.85).aspx
 #Description: executes a preparable statement
 #Status:
-function SQLExecDirect(stmt::Ptr{Void},query::String)
-    @windows_only ret = ccall( (:SQLExecDirect, odbc_dm), stdcall, 
+function SQLExecDirect(stmt::Ptr{Void},query::UTF8String)
+    @windows_only ret = ccall( (:SQLExecDirect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int),
-        stmt,query,sizeof(query)) 
+        stmt,query,sizeof(query))
     @unix_only ret = ccall( (:SQLExecDirect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int),
             stmt,query,sizeof(query))
@@ -575,33 +575,33 @@ end
 function SQLCancel(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLCancel, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLCancel, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
-#### Resultset Metadata Functions #### 
+#### Resultset Metadata Functions ####
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms715393(v=vs.85).aspx
 function SQLNumResultCols(stmt::Ptr{Void},cols::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLNumResultCols, odbc_dm), stdcall,  
-        Int16, (Ptr{Void},Ptr{Int16}), 
-        stmt, cols) 
+    @windows_only ret = ccall( (:SQLNumResultCols, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Ptr{Int16}),
+        stmt, cols)
     @unix_only ret = ccall( (:SQLNumResultCols, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Int16}), 
-            stmt, cols) 
+            Int16, (Ptr{Void},Ptr{Int16}),
+            stmt, cols)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711835(v=vs.85).aspx
 function SQLRowCount(stmt::Ptr{Void},rows::Array{Int,1})
-    @windows_only ret = ccall( (:SQLRowCount, odbc_dm), stdcall,  
-        Int16, (Ptr{Void},Ptr{Int}), 
-        stmt, rows) 
+    @windows_only ret = ccall( (:SQLRowCount, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Ptr{Int}),
+        stmt, rows)
     @unix_only ret = ccall( (:SQLRowCount, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Int}), 
-            stmt, rows) 
+            Int16, (Ptr{Void},Ptr{Int}),
+            stmt, rows)
     return ret
 end
 
@@ -609,21 +609,21 @@ end
 function SQLColAttribute(stmt::Ptr{Void},x::Int,)
     @windows_only ret = ccall( (:SQLColAttribute, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Uint16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
-        stmt,x,) 
+        stmt,x,)
     @unix_only ret = ccall( (:SQLColAttribute, odbc_dm),
             Int16, (Ptr{Void},Uint16,Uint16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
-            stmt,x,) 
+            stmt,x,)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716289(v=vs.85).aspx
 function SQLDescribeCol(stmt::Ptr{Void},x::Int,column_name::Array{Uint8,1},name_length::Array{Int16,1},datatype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLDescribeCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLDescribeCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-        stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
+        stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable)
     @unix_only ret = ccall( (:SQLDescribeCol, odbc_dm),
             Int16, (Ptr{Void},Uint16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-            stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
+            stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable)
     return ret
 end
 
@@ -631,10 +631,10 @@ end
 function SQLDescribeParam(stmt::Ptr{Void},x::Int,sqltype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
     @windows_only ret = ccall( (:SQLDescribeParam, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-        stmt,x,sqltype,column_size,decimal_digits,nullable) 
+        stmt,x,sqltype,column_size,decimal_digits,nullable)
     @unix_only ret = ccall( (:SQLDescribeParam, odbc_dm),
             Int16, (Ptr{Void},Uint16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-            stmt,x,sqltype,column_size,decimal_digits,nullable) 
+            stmt,x,sqltype,column_size,decimal_digits,nullable)
     return ret
 end
 
@@ -642,10 +642,10 @@ end
 function SQLParamData(stmt::Ptr{Void},ptr_buffer::Array{Ptr{Void},1})
     @windows_only ret = ccall( (:SQLParamData, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void}),
-        stmt,ptr_buffer) 
+        stmt,ptr_buffer)
     @unix_only ret = ccall( (:SQLParamData, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void}),
-            stmt,ptr_buffer) 
+            stmt,ptr_buffer)
     return ret
 end
 
@@ -653,64 +653,64 @@ end
 function SQLNumParams(stmt::Ptr{Void},param_count::Array{Int16,1})
     @windows_only ret = ccall( (:SQLNumParams, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Int16}),
-        stmt,param_count) 
+        stmt,param_count)
     @unix_only ret = ccall( (:SQLNumParams, odbc_dm),
             Int16, (Ptr{Void},Ptr{Int16}),
-            stmt,param_count) 
+            stmt,param_count)
     return ret
 end
 
-#### Resultset Retrieval Functions #### 
+#### Resultset Retrieval Functions ####
 #SQLBindParameter
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710963(v=vs.85).aspx
 #Description:
 #valid iotype
-const SQL_PARAM_INPUT = int16(1) 
-const SQL_PARAM_OUTPUT = int16(4) 
-const SQL_PARAM_INPUT_OUTPUT = int16(2) 
-#const SQL_PARAM_INPUT_OUTPUT_STREAM = int16() 
-#const SQL_PARAM_OUTPUT_STREAM = int16() 
+const SQL_PARAM_INPUT = int16(1)
+const SQL_PARAM_OUTPUT = int16(4)
+const SQL_PARAM_INPUT_OUTPUT = int16(2)
+#const SQL_PARAM_INPUT_OUTPUT_STREAM = int16()
+#const SQL_PARAM_OUTPUT_STREAM = int16()
 #Status:
 function SQLBindParameter{T}(stmt::Ptr{Void},x::Int,iotype::Int16,ctype::Int16,sqltype::Int16,column_size::Int,decimal_digits::Int,param_value::Array{T},param_size::Int)
     @windows_only ret = ccall( (:SQLBindParameter, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
-        stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
+        stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL)
     @unix_only ret = ccall( (:SQLBindParameter, odbc_dm),
             Int16, (Ptr{Void},Uint16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
-            stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
+            stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL)
     return ret
 end
 SQLSetParam = SQLBindParameter
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711010(v=vs.85).aspx
 function SQLBindCols{T,N}(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{T,N},jlsize::Int,indicator::Array{Int,1})
-    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
-        stmt,x,ctype,holder,jlsize,indicator) 
+        stmt,x,ctype,holder,jlsize,indicator)
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
             Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
-            stmt,x,ctype,holder,jlsize,indicator) 
+            stmt,x,ctype,holder,jlsize,indicator)
     return ret
 end
 
 function SQLBindCols(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{UTF8String,1},jlsize::Int,indicator::Array{Int,1})
-    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Int16,Ptr{Uint8},Int,Ptr{Int}),
-        stmt,x,ctype,holder,jlsize,indicator) 
+        stmt,x,ctype,holder,jlsize,indicator)
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
             Int16, (Ptr{Void},Uint16,Int16,Ptr{Uint8},Int,Ptr{Int}),
-            stmt,x,ctype,holder,jlsize,indicator) 
+            stmt,x,ctype,holder,jlsize,indicator)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711707(v=vs.85).aspx
-function SQLSetCursorName(stmt::Ptr{Void},cursor::String)
+function SQLSetCursorName(stmt::Ptr{Void},cursor::UTF8String)
     @windows_only ret = ccall( (:SQLSetCursorName, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16),
-        stmt,cursor,length(cursor)) 
+        stmt,cursor,sizeof(cursor))
     @unix_only ret = ccall( (:SQLSetCursorName, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16),
-            stmt,cursor,length(cursor)) 
+            stmt,cursor,sizeof(cursor))
     return ret
 end
 
@@ -718,10 +718,10 @@ end
 function SQLGetCursorName(stmt::Ptr{Void},cursor::Array{Uint8,1},cursor_length::Array{Int16,1})
     @windows_only ret = ccall( (:SQLGetCursorName, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Int16}),
-        stmt,cursor,length(cursor),cursor_length) 
+        stmt,cursor,length(cursor),cursor_length)
     @unix_only ret = ccall( (:SQLGetCursorName, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Int16}),
-            stmt,cursor,length(cursor),cursor_length) 
+            stmt,cursor,length(cursor),cursor_length)
     return ret
 end
 
@@ -729,10 +729,10 @@ end
 function SQLGetData{T,N}(stmt::Ptr{Void},i::Int,ctype::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetData, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
-        stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
+        stmt,i,ctype,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetData, odbc_dm),
             Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
-            stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
+            stmt,i,ctype,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -749,12 +749,12 @@ const SQL_FETCH_RELATIVE = int16(6)
 const SQL_FETCH_BOOKMARK = int16(8)
 #Status:
 function SQLFetchScroll(stmt::Ptr{Void},fetch_orientation::Int16,fetch_offset::Int)
-    @windows_only ret = ccall( (:SQLFetchScroll, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Int16,Int), 
-        stmt,fetch_orientation,fetch_offset) 
+    @windows_only ret = ccall( (:SQLFetchScroll, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Int16,Int),
+        stmt,fetch_orientation,fetch_offset)
     @unix_only ret = ccall( (:SQLFetchScroll, odbc_dm),
-            Int16, (Ptr{Void},Int16,Int), 
-            stmt,fetch_orientation,fetch_offset) 
+            Int16, (Ptr{Void},Int16,Int),
+            stmt,fetch_orientation,fetch_offset)
     return ret
 end
 
@@ -762,10 +762,10 @@ end
 function SQLExtendedFetch(stmt::Ptr{Void},fetch_orientation::Uint16,fetch_offset::Int,row_count_ptr::Array{Int,1},row_status_array::Array{Int16,1})
     @windows_only ret = ccall( (:SQLExtendedFetch, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16,Int,Ptr{Int},Ptr{Int16}),
-        stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
+        stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array)
     @unix_only ret = ccall( (:SQLExtendedFetch, odbc_dm),
             Int16, (Ptr{Void},Uint16,Int,Ptr{Int},Ptr{Int16}),
-            stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
+            stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array)
     return ret
 end
 
@@ -785,10 +785,10 @@ const SQL_LOCK_UNLOCK = uint16(2) #SQLSetPos
 function SQLSetPos{T}(stmt::Ptr{Void},rownumber::T,operation::Uint16,lock_type::Uint16)
     @windows_only ret = ccall( (:SQLSetPos, odbc_dm), stdcall,
         Int16, (Ptr{Void},T,Uint16,Uint16),
-        stmt,rownumber,operation,lock_type) 
+        stmt,rownumber,operation,lock_type)
     @unix_only ret = ccall( (:SQLSetPos, odbc_dm),
             Int16, (Ptr{Void},T,Uint16,Uint16),
-            stmt,rownumber,operation,lock_type) 
+            stmt,rownumber,operation,lock_type)
     return ret
 end #T can be Uint64 or Uint16 it seems
 
@@ -796,10 +796,10 @@ end #T can be Uint64 or Uint16 it seems
 function SQLMoreResults(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLMoreResults, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLMoreResults, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -813,10 +813,10 @@ const SQL_ROLLBACK = int16(1) #SQLEndTran
 function SQLEndTran(handletype::Int16,handle::Ptr{Void},completion_type::Int16)
     @windows_only ret = ccall( (:SQLEndTran, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16),
-        handletype,handle,completion_type) 
+        handletype,handle,completion_type)
     @unix_only ret = ccall( (:SQLEndTran, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16),
-            handletype,handle,completion_type) 
+            handletype,handle,completion_type)
     return ret
 end
 
@@ -824,10 +824,10 @@ end
 function SQLCloseCursor(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLCloseCursor, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLCloseCursor, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -843,99 +843,99 @@ const SQL_FETCH_BY_BOOKMARK = uint16(7) #SQLBulkOperations
 function SQLBulkOperations(stmt::Ptr{Void},operation::Uint16)
     @windows_only ret = ccall( (:SQLBulkOperations, odbc_dm), stdcall,
         Int16, (Ptr{Void},Uint16),
-        stmt,operation) 
+        stmt,operation)
     @unix_only ret = ccall( (:SQLBulkOperations, odbc_dm),
             Int16, (Ptr{Void},Uint16),
-            stmt,operation) 
+            stmt,operation)
     return ret
 end
 
-#### DBMS Meta Functions #### 
+#### DBMS Meta Functions ####
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711683(v=vs.85).aspx
-function SQLColumns(stmt::Ptr{Void},catalog::String,schema::String,table::String,column::String)
+function SQLColumns(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String,column::UTF8String)
     @windows_only ret = ccall( (:SQLColumnPrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),column,sizeof(column))
     @unix_only ret = ccall( (:SQLColumnPrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),column,sizeof(column))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716336(v=vs.85).aspx
-function SQLColumnPrivileges(stmt::Ptr{Void},catalog::String,schema::String,table::String,column::String)
+function SQLColumnPrivileges(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String,column::UTF8String)
     @windows_only ret = ccall( (:SQLColumnPrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),column,sizeof(column))
     @unix_only ret = ccall( (:SQLColumnPrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),column,sizeof(column))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms709315(v=vs.85).aspx
-function SQLForeignKeys(stmt::Ptr{Void},pkcatalog::String,pkschema::String,pktable::String,fkcatalog::String,fkschema::String,fktable::String)
+function SQLForeignKeys(stmt::Ptr{Void},pkcatalog::UTF8String,pkschema::UTF8String,pktable::UTF8String,fkcatalog::UTF8String,fkschema::UTF8String,fktable::UTF8String)
     @windows_only ret = ccall( (:SQLForeignKeys, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable)) 
+        stmt,pkcatalog,sizeof(pkcatalog),pkschema,sizeof(pkschema),pktable,sizeof(pktable),fkcatalog,sizeof(fkcatalog),fkschema,sizeof(fkschema),fktable,sizeof(fktable))
     @unix_only ret = ccall( (:SQLForeignKeys, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable)) 
+            stmt,pkcatalog,sizeof(pkcatalog),pkschema,sizeof(pkschema),pktable,sizeof(pktable),fkcatalog,sizeof(fkcatalog),fkschema,sizeof(fkschema),fktable,sizeof(fktable))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711005(v=vs.85).aspx
-function SQLPrimaryKeys(stmt::Ptr{Void},catalog::String,schema::String,table::String)
+function SQLPrimaryKeys(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String)
     @windows_only ret = ccall( (:SQLPrimaryKeys, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table))
     @unix_only ret = ccall( (:SQLPrimaryKeys, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711701(v=vs.85).aspx
-function SQLProcedureColumns(stmt::Ptr{Void},catalog::String,schema::String,proc::String,column::String)
+function SQLProcedureColumns(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,proc::UTF8String,column::UTF8String)
     @windows_only ret = ccall( (:SQLProcedureColumns, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),proc,sizeof(proc),column,sizeof(column))
     @unix_only ret = ccall( (:SQLProcedureColumns, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),proc,sizeof(proc),column,sizeof(column))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms715368(v=vs.85).aspx
-function SQLProcedures(stmt::Ptr{Void},catalog::String,schema::String,proc::String)
+function SQLProcedures(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,proc::UTF8String)
     @windows_only ret = ccall( (:SQLProcedures, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),proc,sizeof(proc))
     @unix_only ret = ccall( (:SQLProcedures, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),proc,sizeof(proc))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711831(v=vs.85).aspx
-function SQLTables(stmt::Ptr{Void},catalog::String,schema::String,table::String,table_type::String)
+function SQLTables(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String,table_type::UTF8String)
     @windows_only ret = ccall( (:SQLTables, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),table_type,sizeof(table_type))
     @unix_only ret = ccall( (:SQLTables, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),table_type,sizeof(table_type))
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms713565(v=vs.85).aspx
-function SQLTablePrivileges(stmt::Ptr{Void},catalog::String,schema::String,table::String)
+function SQLTablePrivileges(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String)
     @windows_only ret = ccall( (:SQLTablePrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table))
     @unix_only ret = ccall( (:SQLTablePrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table))
     return ret
 end
 
@@ -943,22 +943,22 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711022(v=vs.85).aspx
 #Description:
 #valid unique
-const SQL_INDEX_ALL = uint16(1) 
-const SQL_INDEX_CLUSTERED = uint16(1) 
-const SQL_INDEX_HASHED = uint16(2) 
-const SQL_INDEX_OTHER = uint16(3) 
+const SQL_INDEX_ALL = uint16(1)
+const SQL_INDEX_CLUSTERED = uint16(1)
+const SQL_INDEX_HASHED = uint16(2)
+const SQL_INDEX_OTHER = uint16(3)
 const SQL_INDEX_UNIQUE = uint16(0)
 #valid reserved
-const SQL_ENSURE = uint16(1) 
-const SQL_QUICK = uint16(0) 
+const SQL_ENSURE = uint16(1)
+const SQL_QUICK = uint16(0)
 #Status:
-function SQLStatistics(stmt::Ptr{Void},catalog::String,schema::String,table::String,unique::Uint16,reserved::Uint16)
+function SQLStatistics(stmt::Ptr{Void},catalog::UTF8String,schema::UTF8String,table::UTF8String,unique::Uint16,reserved::Uint16)
     @windows_only ret = ccall( (:SQLStatistics, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Uint16,Uint16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
+        stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),unique,reserved)
     @unix_only ret = ccall( (:SQLStatistics, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Uint16,Uint16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
+            stmt,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),unique,reserved)
     return ret
 end
 
@@ -977,36 +977,36 @@ const SQL_NO_NULLS = int16(0) #SQLSpecialColumns
 const SQL_NULLABLE = int16(1) #SQLSpecialColumns
 #const SQL_NULLABLE_UNKNOWN = int16() #SQLSpecialColumns
 #Status:
-function SQLSpecialColumns(stmt::Ptr{Void},id_type::Int16,catalog::String,schema::String,table::String,scope::Int16,nullable::Int16)
+function SQLSpecialColumns(stmt::Ptr{Void},id_type::Int16,catalog::UTF8String,schema::UTF8String,table::UTF8String,scope::Int16,nullable::Int16)
     @windows_only ret = ccall( (:SQLSpecialColumns, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Int16,Int16),
-        stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable) 
+        stmt,id_type,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),scope,nullable)
     @unix_only ret = ccall( (:SQLSpecialColumns, odbc_dm),
             Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Int16,Int16),
-            stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable) 
+            stmt,id_type,catalog,sizeof(catalog),schema,sizeof(schema),table,sizeof(table),scope,nullable)
     return ret
 end
 
-#### Error Handling Functions #### 
-#TODO: add consts 
+#### Error Handling Functions ####
+#TODO: add consts
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710181(v=vs.85).aspx
 function SQLGetDiagField(handletype::Int16,handle::Ptr{Void},i::Int16,diag_id::Int16,diag_info::Array{Uint,1},buffer_length::Int16,diag_length::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLGetDiagField, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLGetDiagField, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16,Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-        handletype,handle,i,diag_id,diag_info,buffer_length,msg_length) 
+        handletype,handle,i,diag_id,diag_info,buffer_length,msg_length)
     @unix_only ret = ccall( (:SQLGetDiagField, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16,Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-            handletype,handle,i,diag_id,diag_info,buffer_length,msg_length) 
+            handletype,handle,i,diag_id,diag_info,buffer_length,msg_length)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716256(v=vs.85).aspx
 function SQLGetDiagRec(handletype::Int16,handle::Ptr{Void},i::Int16,state::Array{Uint8,1},native::Array{Int,1},error_msg::Array{Uint8,1},msg_length::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLGetDiagRec, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLGetDiagRec, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16,Ptr{Uint8},Ptr{Int},Ptr{Uint8},Int16,Ptr{Int16}),
-        handletype,handle,i,state,native,error_msg,length(error_msg),msg_length) 
+        handletype,handle,i,state,native,error_msg,length(error_msg),msg_length)
     @unix_only ret = ccall( (:SQLGetDiagRec, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16,Ptr{Uint8},Ptr{Int},Ptr{Uint8},Int16,Ptr{Int16}),
-            handletype,handle,i,state,native,error_msg,length(error_msg),msg_length) 
+            handletype,handle,i,state,native,error_msg,length(error_msg),msg_length)
     return ret
 end

--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -7,7 +7,7 @@ let
         @windows_only lib_choices = ["odbc32"]
         @osx_only     lib_choices = ["libodbc.dylib","libiodbc","libiodbc.dylib","libiodbc.1.dylib","libiodbc.2.dylib","libiodbc.3.dylib"]
         local lib
-        for lib in lib_choices 
+        for lib in lib_choices
             try
                 dlopen(lib)
                 succeeded = true
@@ -123,8 +123,8 @@ end
 # SQL_WCHAR                         SQL_C_WCHAR                         Uint16
 # SQL_WVARCHAR                      SQL_C_WCHAR                         Uint16
 # SQL_WLONGVARCHAR                  SQL_C_WCHAR                         Uint16
-# SQL_DECIMAL                       SQL_C_DOUBLE                        Float64                                    
-# SQL_NUMERIC                       SQL_C_DOUBLE                        Float64                                    
+# SQL_DECIMAL                       SQL_C_DOUBLE                        Float64
+# SQL_NUMERIC                       SQL_C_DOUBLE                        Float64
 # SQL_SMALLINT                      SQL_C_SHORT                         Int16
 # SQL_INTEGER                       SQL_C_LONG                          Int32
 # SQL_REAL                          SQL_C_FLOAT                         Float64
@@ -161,7 +161,7 @@ const SQL_LONGVARCHAR   = int16( -1) # Variable length character data. Maximum l
 const SQL_WCHAR         = int16( -8) # Unicode character string of fixed string length n
 const SQL_WVARCHAR      = int16( -9) # Unicode variable-length character string with a maximum string length n
 const SQL_WLONGVARCHAR  = int16(-10) # Unicode variable-length character data. Maximum length is data source–dependent
-const SQL_DECIMAL       = int16(  3) 
+const SQL_DECIMAL       = int16(  3)
 const SQL_NUMERIC       = int16(  2)
 const SQL_SMALLINT      = int16(  5) # Exact numeric value with precision 5 and scale 0 (signed: –32,768 <= n <= 32,767, unsigned: 0 <= n <= 65,535)
 const SQL_INTEGER       = int16(  4) # Exact numeric value with precision 10 and scale 0 (signed: –2[31] <= n <= 2[31] – 1, unsigned: 0 <= n <= 2[32] – 1)
@@ -175,7 +175,7 @@ const SQL_BINARY        = int16( -2) # Binary data of fixed length n.
 const SQL_VARBINARY     = int16( -3) # Variable length binary data of maximum length n. The maximum is set by the user.
 const SQL_LONGVARBINARY = int16( -4) # Variable length binary data. Maximum length is data source–dependent.
 const SQL_TYPE_DATE     = int16( 91) # Year, month, and day fields, conforming to the rules of the Gregorian calendar.
-const SQL_TYPE_TIME     = int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23, 
+const SQL_TYPE_TIME     = int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23,
                                      # valid values for minutes of 00 to 59, and valid values for seconds of 00 to 61. Precision p indicates the seconds precision.
 const SQL_TYPE_TIMESTAMP = int16( 93) # Year, month, day, hour, minute, and second fields, with valid values as defined for the DATE and TIME data types.
 
@@ -252,6 +252,12 @@ immutable SQLTimestamp
 end
 
 Base.string(x::SQLTimestamp) = "$(x.year)-$(x.month)-$(x.day) $(x.hour):$(x.minute):$(x.second)"
+
+Base.isless(x::SQLDate, y::SQLDate) = (x.year, x.month, x.day) < (y.year, y.month, y.day)
+Base.isless(x::SQLTime, y::SQLTime) = (x.hour, x.minute, x.second) < (y.hour, y.minute, y.second)
+Base.isless(x::SQLTimestamp, y::SQLTimestamp) =
+    (x.year, x.month, x.day, x.hour, x.minute, x.second, x.fraction) <
+    (y.year, y.month, y.day, y.hour, y.minute, y.second, y.fraction)
 
 const SQL2C = [
     SQL_CHAR           => SQL_C_CHAR,

--- a/src/userfacing.jl
+++ b/src/userfacing.jl
@@ -1,7 +1,8 @@
-# Connect to DSN, returns Connection object, 
+# Connect to DSN, returns Connection object,
 # also stores Connection information in global default
 # 'conn' object and global 'Connections' connections array
 function connect(dsn::String; usr::String="", pwd::String="")
+    dsn, usr, pwd = utf8(dsn), utf8(usr), utf8(pwd)
     global Connections, conn, env
     env == C_NULL && (env = ODBCAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE))
     dbc = ODBCAllocHandle(SQL_HANDLE_DBC, env)
@@ -18,7 +19,8 @@ function connect(dsn::String; usr::String="", pwd::String="")
     return conn
 end
 
-function advancedconnect(conn_string::String="", driver_prompt::Uint16=SQL_DRIVER_NOPROMPT)
+function advancedconnect(conn_string::String="", driver_prompt::Integer=SQL_DRIVER_NOPROMPT)
+    conn_string, driver_prompt = utf8(conn_string), uint16(driver_prompt)
     global Connections, conn, evn
     env == C_NULL && (env = ODBCAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE))
     dbc = ODBCAllocHandle(SQL_HANDLE_DBC, env)
@@ -35,10 +37,11 @@ function advancedconnect(conn_string::String="", driver_prompt::Uint16=SQL_DRIVE
     return conn
 end
 
-# query: Sends query string to DBMS, 
-# once executed, space is allocated and 
+# query: Sends query string to DBMS,
+# once executed, space is allocated and
 # results and resultset metadata are returned
 function query(querystring::String, conn::Connection=conn; output::Output=DataFrame, delim::Char=',')
+    querystring = utf8(querystring)
     if conn == null_conn
         error("[ODBC]: A valid connection was not specified (and no valid default connection exists)")
     end
@@ -58,7 +61,7 @@ function query(querystring::String, conn::Connection=conn; output::Output=DataFr
                     resultset = ODBCFetchDataFramePush!(conn.stmt_ptr, meta,columns, rowset,indicator)
                 end
             else
-                resultset = ODBCDirectToFile(conn.stmt_ptr, meta,columns, 
+                resultset = ODBCDirectToFile(conn.stmt_ptr, meta,columns,
                                              rowset, output, delim, length(holder))
             end
             push!(holder,resultset)
@@ -70,23 +73,24 @@ function query(querystring::String, conn::Connection=conn; output::Output=DataFr
     return conn.resultset
 end
 
-# sql"..." string literal for convenience; 
+# sql"..." string literal for convenience;
 # it doesn't do anything different than query right now,
 # but we could potentially do some interesting things here
 macro sql_str(s)
     query(s)
 end
 
-# Replaces backticks in the query string with escaped quotes 
+# Replaces backticks in the query string with escaped quotes
 # for convenience in using "" in column names, etc.
 macro query(x)
     :(query(replace($x, '`', '\"')))
 end
 
 # querymeta: Sends query string to DBMS, once executed, return resultset metadata
-# it may seem odd to include the other arguments for querymeta, 
+# it may seem odd to include the other arguments for querymeta,
 # but it's so switching between query and querymeta doesn't require exluding args (convenience)
-function querymeta(querystring::String,conn::Connection=conn; output::Output=DataFrame,delim::Char=',')
+function querymeta(querystring::String, conn::Connection=conn; output::Output=DataFrame, delim::Char=',')
+    querystring = utf8(querystring)
     if conn == null_conn
         error("[ODBC]: A valid connection was not specified (and no valid default connection exists)")
     end
@@ -107,7 +111,7 @@ function disconnect(connection::Connection=conn)
     ODBCFreeStmt!(connection.stmt_ptr)
     SQLDisconnect(connection.dbc_ptr)
     for x = 1:length(Connections)
-        if connection.dsn == Connections[x].dsn && 
+        if connection.dsn == Connections[x].dsn &&
            connection.number == Connections[x].number
             splice!(Connections,x)
             if conn === connection
@@ -126,13 +130,13 @@ end
 function listdrivers()
     global env
     env == C_NULL && (env = ODBCAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE))
-    descriptions = String[]
-    attributes   = String[]
+    descriptions = UTF8String[]
+    attributes   = UTF8String[]
     driver_desc = zeros(Uint8, 256)
     desc_length = zeros(Int16, 1)
     driver_attr = zeros(Uint8, 256)
     attr_length = zeros(Int16, 1)
-    while @SUCCEEDED SQLDrivers(env, driver_desc, desc_length, driver_attr, attr_length)    
+    while @SUCCEEDED SQLDrivers(env, driver_desc, desc_length, driver_attr, attr_length)
         push!(descriptions, ODBCClean(driver_desc, 1, desc_length[1]))
         push!(attributes,   ODBCClean(driver_attr, 1, attr_length[1]))
     end
@@ -143,8 +147,8 @@ end
 function listdsns()
     global env
     env == C_NULL && (env = ODBCAllocHandle(SQL_HANDLE_ENV,SQL_NULL_HANDLE) )
-    descriptions = String[]
-    attributes   = String[]
+    descriptions = UTF8String[]
+    attributes   = UTF8String[]
     dsn_desc    = zeros(Uint8, 256)
     desc_length = zeros(Int16, 1)
     dsn_attr    = zeros(Uint8, 256)

--- a/test/test.jl
+++ b/test/test.jl
@@ -10,8 +10,8 @@ listdrivers()
 # query("select count(*) from exon")
 # query("show columns from exon")
 # query("select phase from exon group by phase")
-# query("select a.exon_id, b.stable_id 
-# 	from exon a 
+# query("select a.exon_id, b.stable_id
+# 	from exon a
 # 	left outer join exon b on a.seq_region_id = b.seq_region_id
 # 	where a.phase = 2 and b.phase = 0")
 # query("select * from exon where phase = -1")


### PR DESCRIPTION
This is probably the more reasonable change that makes everything UTF-8 and addresses https://github.com/quinnj/ODBC.jl/issues/67 for me. However, the question is whether this will work with all drivers or if some of them *require* UTF-16. @jakebolewski, perhaps you can chime in since it seems like you may have introduced some of the UTF-16 stuff that I'm now removing.