### PR TITLE
isless for SQLDate and conversion to Dates.Date

### DIFF
--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -233,6 +233,28 @@ end
 
 Base.string(x::SQLDate) = "$(x.year)-$(x.month)-$(x.day)"
 
+function Base.isless(x::SQLDate,y::SQLDate)
+  if x.year > y.year
+    return false
+  elseif x.year < y.year
+    return true
+  elseif x.year == y.year
+    if x.month > y.month
+      return false
+    elseif x.month < y.month
+      return true
+    elseif x.month == y.month
+      if x.day < y.day
+        return true
+      else
+        return false
+      end
+    end
+  end
+end
+
+Base.convert(::Type{Dates.Date},x::ODBC.SQLDate) = Dates.Date(x.year,x.month, x.day)
+
 immutable SQLTime
     hour::Int16
     minute::Int16


### PR DESCRIPTION
Proposal to add functionality for isless on the SQLDate type which allows for comparison and searchsorted to work for the SQLDate type.  

Also conversion between SQLDate and Dates.Date is proposed. Tested with both Julia v0.3.11 and v0.4.0.