### PR TITLE
Fixing Travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - mysql
 
 before_install:
-  - mysql --version
+  - sudo apt-get update
   - sudo apt-get install libmyodbc libsqliteodbc unixodbc unixodbc-dev
   - sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini
   - sudo odbcinst -i -s -l -f ./test/odbc.ini


### PR DESCRIPTION
Installation of following packages are failing on Travis server: libmyodbc, libsqliteodbc, unixodbc, unixodbc-dev . These packages are required to setup a DSN for MySQL. This commit will fix the installation issues.