### PR TITLE
Removed forced type conversion of query string to utf16.

### DIFF
--- a/src/backend.jl
+++ b/src/backend.jl
@@ -40,7 +40,7 @@ end
 
 # Send query to DMBS
 function ODBCQueryExecute(stmt::Ptr{Void}, querystring::AbstractString)
-    if @FAILED SQLExecDirect(stmt, utf16(querystring))
+    if @FAILED SQLExecDirect(stmt, querystring)
         ODBCError(SQL_HANDLE_STMT,stmt)
         error("[ODBC]: SQLExecDirect failed; Return Code: $ret")
     end


### PR DESCRIPTION
I've only been able to test this on one machine, so not sure if this breaks for those users that required the explicit `utf16` call.